### PR TITLE
chore: clean up dependencies, fix CI/CD, and optimize Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI - 构建、测试和质量检查
 
 on:
   push:
-    branches: [main, develop]
+    branches: [master]
   pull_request:
-    branches: [main, develop]
+    branches: [master]
 
 jobs:
   check:
@@ -48,11 +48,10 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
 
   build:
-    name: 构建可执行文件
+    name: 构建 ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -63,13 +62,18 @@ jobs:
           - os: macos-latest
             target: x86_64-apple-darwin
             binary_name: claude_code_rs
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            binary_name: claude_code_rs
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
       - name: 构建 Release 版本
         run: cargo build --release --target ${{ matrix.target }}
       - name: 上传构建产物
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os }}-binary
+          name: ${{ matrix.target }}-binary
           path: target/${{ matrix.target }}/release/${{ matrix.binary_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,10 @@ on:
 
 jobs:
   build:
-    name: 构建 ${{ matrix.os }}
+    name: 构建 ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -25,16 +24,22 @@ jobs:
             target: x86_64-apple-darwin
             artifact: claude_code_rs
             asset_name: claude-code-rust-macos-x86_64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: claude_code_rs
+            asset_name: claude-code-rust-macos-arm64
 
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      
+        with:
+          targets: ${{ matrix.target }}
+
       - name: 构建 Release
         run: cargo build --release --target ${{ matrix.target }}
-      
+
       - name: 上传资源到发布
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: target/${{ matrix.target }}/release/${{ matrix.artifact }}
 
@@ -43,12 +48,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v2
-      
-      - name: 构建 Docker 镜像
-        run: |
-          docker build -t claude-code-rust:${{ github.ref_name }} .
-          docker tag claude-code-rust:${{ github.ref_name }} claude-code-rust:latest
-      
-      - name: 验证镜像
-        run: docker run --rm claude-code-rust:latest --version
+      - uses: docker/setup-buildx-action@v3
+
+      - name: 构建并推送 Docker 镜像
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: |
+            claude-code-rust:${{ github.ref_name }}
+            claude-code-rust:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,6 @@ serde_json = "1.0"
 
 # File system
 walkdir = "2.5"
-glob = "0.3"
-notify = "6.1"
 
 # Terminal UI
 crossterm = { version = "0.27", features = ["event-stream"] }
@@ -34,7 +32,6 @@ ratatui = "0.26"
 which = "6.0"
 
 # Configuration
-config = "0.14"
 toml = "0.8"
 
 # Logging
@@ -44,10 +41,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Error handling
 thiserror = "1.0"
 anyhow = "1.0"
-
-# Memory & Cache
-lru = "0.12"
-dashmap = "5.5"
 
 # Crypto & Auth
 sha2 = "0.10"
@@ -59,7 +52,6 @@ async-trait = "0.1"
 
 # Regex & Parsing
 regex = "1.10"
-nom = "7.1"
 
 # Time
 chrono = { version = "0.4", features = ["serde"] }
@@ -70,15 +62,15 @@ uuid = { version = "1.8", features = ["v4", "serde"] }
 # Directories
 dirs = "5.0"
 
-# Diff
-similar = "2.5"
-
-# Markdown
-pulldown-cmark = "0.10"
-
 [dev-dependencies]
 tempfile = "3.10"
 mockall = "0.12"
+
+[profile.release]
+opt-level = 3
+lto = true
+strip = true
+codegen-units = 1
 
 [[bin]]
 name = "claude-code"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,52 +2,49 @@
 # 多阶段构建：Claude Code Rust 容器镜像
 # ==========================================
 
-# 阶段 1: 构建阶段
-FROM rust:1.75 as builder
+# 阶段 1: 构建阶段 (使用 musl 静态链接，兼容 Alpine)
+FROM rust:1.82-bookworm AS builder
+
+RUN rustup target add x86_64-unknown-linux-musl
 
 WORKDIR /build
 
-# 复制依赖文件
-COPY Cargo.toml Cargo.lock ./
+# 依赖缓存层
+COPY Cargo.toml ./
+RUN mkdir src && echo "fn main() {}" > src/main.rs
+RUN cargo build --release --target x86_64-unknown-linux-musl
+RUN rm -rf src
 
-# 复制源代码
+# 复制源代码并构建
 COPY src ./src
-
-# 构建优化版本
-RUN cargo build --release
+RUN touch src/main.rs && cargo build --release --target x86_64-unknown-linux-musl
 
 # ==========================================
 # 阶段 2: 运行时阶段（最小镜像）
-FROM alpine:3.18
+FROM alpine:3.20
 
 LABEL maintainer="claude-code-rust"
 LABEL description="High-performance Claude Code CLI - Rust Edition"
 LABEL version="0.1.0"
 
 # 安装必要的运行时依赖
-RUN apk add --no-cache \
-    ca-certificates \
-    curl \
-    libssl3 \
-    libcrypto3
+RUN apk add --no-cache ca-certificates curl
 
 WORKDIR /app
 
-# 从构建阶段复制二进制文件
-COPY --from=builder /build/target/release/claude-code /usr/local/bin/
+# 从构建阶段复制静态链接的二进制文件
+COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/claude-code /usr/local/bin/
 
-# 创建配置目录
-RUN mkdir -p /home/claude/.config/claude-code
+# 创建配置目录和非特权用户
+RUN mkdir -p /home/claude/.config/claude-code && \
+    addgroup -D claude && \
+    adduser -D -G claude claude && \
+    chown -R claude:claude /home/claude
 
 # 设置环境变量
 ENV PATH="/usr/local/bin:${PATH}" \
     HOME="/home/claude" \
     XDG_CONFIG_HOME="/home/claude/.config"
-
-# 创建非特权用户
-RUN addgroup -D claude && \
-    adduser -D -G claude claude && \
-    chown -R claude:claude /home/claude
 
 # 切换到非特权用户
 USER claude
@@ -67,10 +64,7 @@ CMD ["--help"]
 # docker build -t claude-code-rust:latest .
 # docker build -t claude-code-rust:0.1.0 .
 #
-# 运行数据卷挂载：
-# docker run -it --rm -v ~/.config/claude-code:/home/claude/.config/claude-code claude-code-rust
-# 
-# 使用示例：
-# docker run --rm claude-code-rust --version
+# 运行：
 # docker run -it --rm claude-code-rust repl
-# docker run --rm claude-code-rust query --prompt "What is Rust?"
+# docker run --rm claude-code-rust --version
+# docker run -it --rm -v ~/.claude-code:/home/claude/.config/claude-code claude-code-rust


### PR DESCRIPTION
- Remove 8 unused crate dependencies (dashmap, lru, similar, pulldown-cmark, nom, notify, config, glob) to reduce compile time and binary size
- Add [profile.release] with LTO, strip, and single codegen-unit for optimized production builds
- Fix CI branch names: main/develop → master (matches actual branch)
- Upgrade upload-artifact v3 → v4 (deprecated)
- Add aarch64-apple-darwin build target for Apple Silicon
- Upgrade release workflow: softprops/action-gh-release v1 → v2, docker/setup-buildx-action v2 → v3, docker/build-push-action v5
- Fix Dockerfile: use musl static linking for Alpine compatibility, add dependency cache layer, upgrade rust:1.75 → 1.82, alpine:3.18 → 3.20